### PR TITLE
Updated Manifest to allow external storage permissions

### DIFF
--- a/src/fiskaltrust.AndroidLauncher.Grpc/Properties/AndroidManifest.xml
+++ b/src/fiskaltrust.AndroidLauncher.Grpc/Properties/AndroidManifest.xml
@@ -5,4 +5,6 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/src/fiskaltrust.AndroidLauncher.Http/Properties/AndroidManifest.xml
+++ b/src/fiskaltrust.AndroidLauncher.Http/Properties/AndroidManifest.xml
@@ -13,4 +13,6 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
We encounter issues on devices that are using Swissbit MicroSd Cards.
We strongly believe that these permissions are missing.