### PR TITLE
Fixed error handling on startup

### DIFF
--- a/src/fiskaltrust.AndroidLauncher.Common/AndroidService/MiddlewareLauncherService.cs
+++ b/src/fiskaltrust.AndroidLauncher.Common/AndroidService/MiddlewareLauncherService.cs
@@ -41,7 +41,7 @@ namespace fiskaltrust.AndroidLauncher.Common.AndroidService
 
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.File(path: Path.Combine(FileLoggerHelper.LogDirectory.FullName, FileLoggerHelper.LogFilename), rollingInterval: RollingInterval.Day,
-                    retainedFileCountLimit: 31, shared: true, fileSizeLimitBytes: 100 * 1024 * 1024)
+                    retainedFileCountLimit: 31)
                 .CreateLogger();
 
             try
@@ -73,7 +73,7 @@ namespace fiskaltrust.AndroidLauncher.Common.AndroidService
                     }
                     catch (Exception ex)
                     {
-                        Log.Logger.Error(ex, "AdminEndpointService starting failed...");
+                        Log.Logger.Error(ex, "AdminEndpointService starting failed.");
                     }
 
                     await _launcher.StartAsync();
@@ -88,6 +88,9 @@ namespace fiskaltrust.AndroidLauncher.Common.AndroidService
             }
             catch (Exception ex)
             {
+                if (ex.InnerException != null)
+                    ex = ex.InnerException;
+
                 Log.Logger.Error(ex, "An error occured while trying to start the fiskaltrust Android Launcher.");
 
                 if (ex is RemountRequiredException remountRequiredEx)
@@ -106,7 +109,7 @@ namespace fiskaltrust.AndroidLauncher.Common.AndroidService
                     SetState(LauncherState.Error);
                 }
 
-                throw;
+                return StartCommandResult.NotSticky;
             }
         }
 
@@ -129,7 +132,7 @@ namespace fiskaltrust.AndroidLauncher.Common.AndroidService
             {
                 StopForeground(true);
             }
-            
+
             Log.CloseAndFlush();
             base.OnDestroy();
         }
@@ -192,7 +195,7 @@ namespace fiskaltrust.AndroidLauncher.Common.AndroidService
             };
             var text = state switch
             {
-                LauncherState.NotConnected => "The fiskaltrust Middleware is on standby. Starting will take a few seconds, depending on the TSE.",
+                LauncherState.NotConnected => "The fiskaltrust Middleware is starting. This will take a few seconds, depending on the TSE.",
                 LauncherState.Connected => "The fiskaltrust Middleware is running.",
                 LauncherState.Error => "An error occured in the fiskaltrust Middleware. Please restart it.",
                 _ => throw new NotImplementedException(),

--- a/src/fiskaltrust.AndroidLauncher.Common/Hosting/AdminEndpointService.cs
+++ b/src/fiskaltrust.AndroidLauncher.Common/Hosting/AdminEndpointService.cs
@@ -31,7 +31,7 @@ namespace fiskaltrust.AndroidLauncher.Common.Hosting
 
         public async Task StartAsync()
         {
-            if(_host != null)
+            if (_host != null)
             {
                 await StopAsync();
             }
@@ -61,13 +61,13 @@ namespace fiskaltrust.AndroidLauncher.Common.Hosting
                                 return;
                             }
 
-                            if(!await AuthenticateAsync(request.Headers["cashboxid"], request.Headers["accesstoken"]))
+                            if (!await AuthenticateAsync(request.Headers["cashboxid"], request.Headers["accesstoken"]))
                             {
                                 response.StatusCode = StatusCodes.Status403Forbidden;
                                 return;
                             }
 
-                            var fileToSend = FileLoggerHelper.LogDirectory.GetFiles("*.log").OrderByDescending(f=>f.LastWriteTime).FirstOrDefault();
+                            var fileToSend = FileLoggerHelper.LogDirectory.GetFiles("*.log").OrderByDescending(f => f.LastWriteTime).FirstOrDefault();
 
                             if (fileToSend != null)
                             {
@@ -84,10 +84,10 @@ namespace fiskaltrust.AndroidLauncher.Common.Hosting
                 .Build();
 
             await _host.StartAsync();
-            
+
             Log.Logger.Information($"Admin endpoint is listening at '{URL}'.");
         }
-        
+
         private IFileInfo GetIFileInfo(string fileName)
         {
             IFileProvider provider = new PhysicalFileProvider(AppDomain.CurrentDomain.BaseDirectory);

--- a/src/fiskaltrust.AndroidLauncher.Http/Broadcasting/StartLauncherBroadcastReceiver.cs
+++ b/src/fiskaltrust.AndroidLauncher.Http/Broadcasting/StartLauncherBroadcastReceiver.cs
@@ -3,6 +3,7 @@ using Android.Content;
 using fiskaltrust.AndroidLauncher.Common.AndroidService;
 using fiskaltrust.AndroidLauncher.Common.Constants;
 using fiskaltrust.AndroidLauncher.Common.Extensions;
+using fiskaltrust.AndroidLauncher.Common.Services;
 using Microsoft.Extensions.Logging;
 using System;
 
@@ -19,6 +20,11 @@ namespace fiskaltrust.AndroidLauncher.Http.Broadcasting
             var isSandbox = intent.GetBooleanExtra("sandbox", false);
             var logLevel = Enum.TryParse(intent.GetStringExtra("loglevel"), out LogLevel level) ? level : LogLevel.Information;
             var scuParams = intent.GetScuConfigParameters();
+
+            if (StateProvider.Instance.CurrentValue.CurrentState == State.Error)
+            {
+                MiddlewareLauncherService.Stop<MiddlewareLauncherHttpService>();
+            }
 
             MiddlewareLauncherService.Start<MiddlewareLauncherHttpService>(cashboxId, accessToken, isSandbox, logLevel, scuParams);
         }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.3.24-rc1",
+    "version": "1.3.24",
     "releaseBranches": [
       "^refs/heads/master$",
       "^refs/heads/release/\\d+(?:\\.\\d+)*(?:-.*)?$",


### PR DESCRIPTION
With the latest changes, the Middleware service re-threw exceptions that occurred during startup, which led to a crash.

These changes 
1. Make sure that the service does not crash on exceptions during startup
2. Properly handle a Launcher instance in an error state when the start intent is received again