### PR TITLE
Fixed smoke tests

### DIFF
--- a/azure-pipelines/middleware-launcher-android-ci-cd.yml
+++ b/azure-pipelines/middleware-launcher-android-ci-cd.yml
@@ -200,6 +200,12 @@ stages:
             inputs:
               version: "20.x"
 
+          - task: JavaToolInstaller@0
+            inputs:
+              versionSpec: "11"
+              jdkArchitectureOption: "x64"
+              jdkSourceOption: "PreInstalled"
+
           - task: NuGetCommand@2
             inputs:
               command: "restore"

--- a/azure-pipelines/middleware-launcher-android-ci-cd.yml
+++ b/azure-pipelines/middleware-launcher-android-ci-cd.yml
@@ -235,7 +235,7 @@ stages:
           - pwsh: |             
               Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x64.dll" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x64.dll.bak"
               Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x86.dll" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x86.dll.bak"
-              C:\npm\prefix\appcenter.cmd test prepare uitest --artifacts-dir $(Build.ArtifactStagingDirectory)/AppCenterTest --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk --build-dir $(testOutputDirectory) --uitest-tools-dir test-tools/Xamarin.UITest.3.2.8/tools --include-category grpc
+              C:\npm\prefix\appcenter.cmd test prepare uitest --artifacts-dir $(Build.ArtifactStagingDirectory)/AppCenterTest --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk --build-dir $(testOutputDirectory) --uitest-tools-dir test-tools/Xamarin.UITest.4.3.3/tools --include-category grpc
               Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x64.dll.bak" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x64.dll"
               Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x86.dll.bak" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x86.dll"
 
@@ -245,7 +245,7 @@ stages:
           - pwsh: |             
               Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x64.dll" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x64.dll.bak"
               Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x86.dll" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x86.dll.bak"
-              C:\npm\prefix\appcenter.cmd test prepare uitest --artifacts-dir $(Build.ArtifactStagingDirectory)/AppCenterTest --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk --build-dir $(testOutputDirectory) --uitest-tools-dir test-tools/Xamarin.UITest.3.2.8/tools --include-category http
+              C:\npm\prefix\appcenter.cmd test prepare uitest --artifacts-dir $(Build.ArtifactStagingDirectory)/AppCenterTest --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk --build-dir $(testOutputDirectory) --uitest-tools-dir test-tools/Xamarin.UITest.4.3.3/tools --include-category http
               Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x64.dll.bak" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x64.dll"
               Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x86.dll.bak" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x86.dll"
 

--- a/azure-pipelines/middleware-launcher-android-ci-cd.yml
+++ b/azure-pipelines/middleware-launcher-android-ci-cd.yml
@@ -233,21 +233,21 @@ stages:
           # We cannot use the AppCenter task, as it executes both test preparation and execution at once - and the preparation fails because it tries to scan the gRPC DLLs for tests, treats them as .NET files, and fails.
           # Instead, we're executing these 2 steps manually and move the DLLs out of the way
           - pwsh: |             
-              Rename-Item -Path "grpc_csharp_ext.x64.dll" -NewName "grpc_csharp_ext.x64.dll.bak"
-              Rename-Item -Path "grpc_csharp_ext.x86.dll" -NewName "grpc_csharp_ext.x86.dll.bak"
+              Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x64.dll" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x64.dll.bak"
+              Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x86.dll" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x86.dll.bak"
               C:\npm\prefix\appcenter.cmd test prepare uitest --artifacts-dir $(Build.ArtifactStagingDirectory)/AppCenterTest --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk --build-dir $(testOutputDirectory) --uitest-tools-dir test-tools/Xamarin.UITest.3.2.8/tools --include-category grpc
-              Rename-Item -Path "grpc_csharp_ext.x64.dll.bak" -NewName "grpc_csharp_ext.x64.dll"
-              Rename-Item -Path "grpc_csharp_ext.x86.dll.bak" -NewName "grpc_csharp_ext.x86.dll"
+              Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x64.dll.bak" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x64.dll"
+              Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x86.dll.bak" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x86.dll"
 
               C:\npm\prefix\appcenter.cmd test run manifest --manifest-path $(Build.ArtifactStagingDirectory)/AppCenterTest/manifest.json --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk --app fiskaltrust/fiskaltrust.Launcher --devices fiskaltrust/launcher --test-series master --locale en_US --test-parameter "test_env=CASHBOXID=$(CreateGrpcCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateGrpcCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateGrpcCashBox.url)" --token $(AppCenterToken)
             displayName: Prepare and run smoke tests (gRPC)
 
           - pwsh: |             
-              Rename-Item -Path "grpc_csharp_ext.x64.dll" -NewName "grpc_csharp_ext.x64.dll.bak"
-              Rename-Item -Path "grpc_csharp_ext.x86.dll" -NewName "grpc_csharp_ext.x86.dll.bak"
+              Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x64.dll" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x64.dll.bak"
+              Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x86.dll" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x86.dll.bak"
               C:\npm\prefix\appcenter.cmd test prepare uitest --artifacts-dir $(Build.ArtifactStagingDirectory)/AppCenterTest --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk --build-dir $(testOutputDirectory) --uitest-tools-dir test-tools/Xamarin.UITest.3.2.8/tools --include-category http
-              Rename-Item -Path "grpc_csharp_ext.x64.dll.bak" -NewName "grpc_csharp_ext.x64.dll"
-              Rename-Item -Path "grpc_csharp_ext.x86.dll.bak" -NewName "grpc_csharp_ext.x86.dll"
+              Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x64.dll.bak" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x64.dll"
+              Rename-Item -Path "$(testOutputDirectory)/grpc_csharp_ext.x86.dll.bak" -NewName "$(testOutputDirectory)/grpc_csharp_ext.x86.dll"
 
               C:\npm\prefix\appcenter.cmd test run manifest --manifest-path $(Build.ArtifactStagingDirectory)/AppCenterTest/manifest.json --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk --app fiskaltrust/fiskaltrust.Launcher --devices fiskaltrust/launcher --test-series master --locale en_US --test-parameter "test_env=CASHBOXID=$(CreateHttpCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateHttpCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateHttpCashBox.url)" --token $(AppCenterToken)
             displayName: Prepare and run smoke tests (HTTP)

--- a/azure-pipelines/middleware-launcher-android-ci-cd.yml
+++ b/azure-pipelines/middleware-launcher-android-ci-cd.yml
@@ -198,7 +198,7 @@ stages:
 
           - task: UseNode@1
             inputs:
-              version: "24.x"
+              version: "20.x"
 
           - task: NuGetCommand@2
             inputs:

--- a/azure-pipelines/middleware-launcher-android-ci-cd.yml
+++ b/azure-pipelines/middleware-launcher-android-ci-cd.yml
@@ -200,12 +200,6 @@ stages:
             inputs:
               version: "20.x"
 
-          - task: JavaToolInstaller@0
-            inputs:
-              versionSpec: "11"
-              jdkArchitectureOption: "x64"
-              jdkSourceOption: "PreInstalled"
-
           - task: NuGetCommand@2
             inputs:
               command: "restore"
@@ -251,38 +245,6 @@ stages:
 
               C:\npm\prefix\appcenter.cmd test run manifest --manifest-path $(Build.ArtifactStagingDirectory)/AppCenterTest/manifest.json --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk --app fiskaltrust/fiskaltrust.Launcher --devices fiskaltrust/launcher --test-series master --locale en_US --test-parameter "test_env=CASHBOXID=$(CreateHttpCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateHttpCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateHttpCashBox.url)" --token $(AppCenterToken)
             displayName: Prepare and run smoke tests (HTTP)
-
-          # - task: AppCenterTest@1
-          #   inputs:
-          #     appFile: "$(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk"
-          #     artifactsDirectory: "$(Build.ArtifactStagingDirectory)/AppCenterTest"
-          #     frameworkOption: "uitest"
-          #     uiTestBuildDirectory: "$(testOutputDirectory)"
-          #     uiTestToolsDirectory: "test-tools/Xamarin.UITest.4.3.3/tools"
-          #     credentialsOption: "serviceEndpoint"
-          #     serverEndpoint: "VS App Center"
-          #     appSlug: "fiskaltrust/fiskaltrust.Launcher"
-          #     devices: "fiskaltrust/launcher"
-          #     localeOption: "en_US"
-          #     prepareOptions: "--include-category grpc"
-          #     runOptions: --test-parameter "test_env=CASHBOXID=$(CreateGrpcCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateGrpcCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateGrpcCashBox.url)"
-          #   displayName: Smoke tests (gRPC)
-
-          # - task: AppCenterTest@1
-          #   inputs:
-          #     appFile: "$(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk"
-          #     artifactsDirectory: "$(Build.ArtifactStagingDirectory)/AppCenterTest"
-          #     frameworkOption: "uitest"
-          #     uiTestBuildDirectory: "$(testOutputDirectory)"
-          #     uiTestToolsDirectory: "test-tools/Xamarin.UITest.4.3.3/tools"
-          #     credentialsOption: "serviceEndpoint"
-          #     serverEndpoint: "VS App Center"
-          #     appSlug: "fiskaltrust/fiskaltrust.Launcher"
-          #     devices: "fiskaltrust/launcher"
-          #     localeOption: "en_US"
-          #     prepareOptions: "--include-category http"
-          #     runOptions: --test-parameter "test_env=CASHBOXID=$(CreateHttpCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateHttpCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateHttpCashBox.url)"
-          #   displayName: Smoke tests (HTTP)
 
       - job: Cleanup
         dependsOn: SmokeTest

--- a/azure-pipelines/middleware-launcher-android-ci-cd.yml
+++ b/azure-pipelines/middleware-launcher-android-ci-cd.yml
@@ -230,44 +230,59 @@ stages:
               command: "custom"
               customCommand: "-g install appcenter-cli@latest"
 
-          - pwsh: |
-              # lists all files in tools folder
-              Get-ChildItem -Path "$(testOutputDirectory)" -Recurse -File | ForEach-Object {
-                # prints the file name
-                Write-Host $_.Name
-              }
+          # We cannot use the AppCenter task, as it executes both test preparation and execution at once - and the preparation fails because it tries to scan the gRPC DLLs for tests, treats them as .NET files, and fails.
+          # Instead, we're executing these 2 steps manually and move the DLLs out of the way
+          - pwsh: |             
+              Rename-Item -Path "grpc_csharp_ext.x64.dll" -NewName "grpc_csharp_ext.x64.dll.bak"
+              Rename-Item -Path "grpc_csharp_ext.x86.dll" -NewName "grpc_csharp_ext.x86.dll.bak"
+              C:\npm\prefix\appcenter.cmd test prepare uitest --artifacts-dir $(Build.ArtifactStagingDirectory)/AppCenterTest --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk --build-dir $(testOutputDirectory) --uitest-tools-dir test-tools/Xamarin.UITest.3.2.8/tools --include-category grpc
+              Rename-Item -Path "grpc_csharp_ext.x64.dll.bak" -NewName "grpc_csharp_ext.x64.dll"
+              Rename-Item -Path "grpc_csharp_ext.x86.dll.bak" -NewName "grpc_csharp_ext.x86.dll"
 
-          - task: AppCenterTest@1
-            inputs:
-              appFile: "$(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk"
-              artifactsDirectory: "$(Build.ArtifactStagingDirectory)/AppCenterTest"
-              frameworkOption: "uitest"
-              uiTestBuildDirectory: "$(testOutputDirectory)"
-              uiTestToolsDirectory: "test-tools/Xamarin.UITest.4.3.3/tools"
-              credentialsOption: "serviceEndpoint"
-              serverEndpoint: "VS App Center"
-              appSlug: "fiskaltrust/fiskaltrust.Launcher"
-              devices: "fiskaltrust/launcher"
-              localeOption: "en_US"
-              prepareOptions: "--include-category grpc"
-              runOptions: --test-parameter "test_env=CASHBOXID=$(CreateGrpcCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateGrpcCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateGrpcCashBox.url)"
-            displayName: Smoke tests (gRPC)
+              C:\npm\prefix\appcenter.cmd test run manifest --manifest-path $(Build.ArtifactStagingDirectory)/AppCenterTest/manifest.json --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk --app fiskaltrust/fiskaltrust.Launcher --devices fiskaltrust/launcher --test-series master --locale en_US --test-parameter "test_env=CASHBOXID=$(CreateGrpcCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateGrpcCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateGrpcCashBox.url)" --token $(AppCenterToken)
+            displayName: Prepare and run smoke tests (gRPC)
 
-          - task: AppCenterTest@1
-            inputs:
-              appFile: "$(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk"
-              artifactsDirectory: "$(Build.ArtifactStagingDirectory)/AppCenterTest"
-              frameworkOption: "uitest"
-              uiTestBuildDirectory: "$(testOutputDirectory)"
-              uiTestToolsDirectory: "test-tools/Xamarin.UITest.4.3.3/tools"
-              credentialsOption: "serviceEndpoint"
-              serverEndpoint: "VS App Center"
-              appSlug: "fiskaltrust/fiskaltrust.Launcher"
-              devices: "fiskaltrust/launcher"
-              localeOption: "en_US"
-              prepareOptions: "--include-category http"
-              runOptions: --test-parameter "test_env=CASHBOXID=$(CreateHttpCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateHttpCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateHttpCashBox.url)"
-            displayName: Smoke tests (HTTP)
+          - pwsh: |             
+              Rename-Item -Path "grpc_csharp_ext.x64.dll" -NewName "grpc_csharp_ext.x64.dll.bak"
+              Rename-Item -Path "grpc_csharp_ext.x86.dll" -NewName "grpc_csharp_ext.x86.dll.bak"
+              C:\npm\prefix\appcenter.cmd test prepare uitest --artifacts-dir $(Build.ArtifactStagingDirectory)/AppCenterTest --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk --build-dir $(testOutputDirectory) --uitest-tools-dir test-tools/Xamarin.UITest.3.2.8/tools --include-category http
+              Rename-Item -Path "grpc_csharp_ext.x64.dll.bak" -NewName "grpc_csharp_ext.x64.dll"
+              Rename-Item -Path "grpc_csharp_ext.x86.dll.bak" -NewName "grpc_csharp_ext.x86.dll"
+
+              C:\npm\prefix\appcenter.cmd test run manifest --manifest-path $(Build.ArtifactStagingDirectory)/AppCenterTest/manifest.json --app-path $(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk --app fiskaltrust/fiskaltrust.Launcher --devices fiskaltrust/launcher --test-series master --locale en_US --test-parameter "test_env=CASHBOXID=$(CreateHttpCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateHttpCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateHttpCashBox.url)" --token $(AppCenterToken)
+            displayName: Prepare and run smoke tests (HTTP)
+
+          # - task: AppCenterTest@1
+          #   inputs:
+          #     appFile: "$(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.grpc.$(Build.BuildNumber).apk"
+          #     artifactsDirectory: "$(Build.ArtifactStagingDirectory)/AppCenterTest"
+          #     frameworkOption: "uitest"
+          #     uiTestBuildDirectory: "$(testOutputDirectory)"
+          #     uiTestToolsDirectory: "test-tools/Xamarin.UITest.4.3.3/tools"
+          #     credentialsOption: "serviceEndpoint"
+          #     serverEndpoint: "VS App Center"
+          #     appSlug: "fiskaltrust/fiskaltrust.Launcher"
+          #     devices: "fiskaltrust/launcher"
+          #     localeOption: "en_US"
+          #     prepareOptions: "--include-category grpc"
+          #     runOptions: --test-parameter "test_env=CASHBOXID=$(CreateGrpcCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateGrpcCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateGrpcCashBox.url)"
+          #   displayName: Smoke tests (gRPC)
+
+          # - task: AppCenterTest@1
+          #   inputs:
+          #     appFile: "$(build.artifactStagingDirectory)/eu.fiskaltrust.androidlauncher.http.$(Build.BuildNumber).apk"
+          #     artifactsDirectory: "$(Build.ArtifactStagingDirectory)/AppCenterTest"
+          #     frameworkOption: "uitest"
+          #     uiTestBuildDirectory: "$(testOutputDirectory)"
+          #     uiTestToolsDirectory: "test-tools/Xamarin.UITest.4.3.3/tools"
+          #     credentialsOption: "serviceEndpoint"
+          #     serverEndpoint: "VS App Center"
+          #     appSlug: "fiskaltrust/fiskaltrust.Launcher"
+          #     devices: "fiskaltrust/launcher"
+          #     localeOption: "en_US"
+          #     prepareOptions: "--include-category http"
+          #     runOptions: --test-parameter "test_env=CASHBOXID=$(CreateHttpCashBox.cashboxId)" --test-parameter "test_env=ACCESSTOKEN=$(CreateHttpCashBox.accessToken)" --test-parameter "test_env=URL=$(CreateHttpCashBox.url)"
+          #   displayName: Smoke tests (HTTP)
 
       - job: Cleanup
         dependsOn: SmokeTest

--- a/azure-pipelines/middleware-launcher-android-ci-cd.yml
+++ b/azure-pipelines/middleware-launcher-android-ci-cd.yml
@@ -198,7 +198,7 @@ stages:
 
           - task: UseNode@1
             inputs:
-              version: "10.15.1"
+              version: "24.x"
 
           - task: NuGetCommand@2
             inputs:
@@ -223,6 +223,13 @@ stages:
             inputs:
               command: "custom"
               customCommand: "-g install appcenter-cli@latest"
+
+          - pwsh: |
+              # lists all files in tools folder
+              Get-ChildItem -Path "$(testOutputDirectory)" -Recurse -File | ForEach-Object {
+                # prints the file name
+                Write-Host $_.Name
+              }
 
           - task: AppCenterTest@1
             inputs:


### PR DESCRIPTION
Seems like we cannot use the AppCenter task, as it executes both test preparation and execution at once - and the preparation fails because it tries to scan the gRPC DLLs for tests, treats them as .NET files, and fails. Instead, we're now executing these 2 steps manually and move the gRPC DLLs "out of the way" before the preparation, and back afterwards before the tests are ran.