### PR TITLE
Add 'USE_EXACT_ALARM' permission in AndroidManifest

### DIFF
--- a/src/fiskaltrust.AndroidLauncher.Grpc/Properties/AndroidManifest.xml
+++ b/src/fiskaltrust.AndroidLauncher.Grpc/Properties/AndroidManifest.xml
@@ -9,4 +9,5 @@
 	<uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 	<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+	<uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 </manifest>

--- a/src/fiskaltrust.AndroidLauncher.Http/Properties/AndroidManifest.xml
+++ b/src/fiskaltrust.AndroidLauncher.Http/Properties/AndroidManifest.xml
@@ -8,4 +8,5 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 	<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+	<uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 </manifest>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

{Summary of the changes}

## Description

{Detail}

Fixes #{issue number}
