### PR TITLE
Use non-exact alarms in Android 14+

### DIFF
--- a/src/fiskaltrust.AndroidLauncher.Grpc/Broadcasting/StartLauncherBroadcastReceiver.cs
+++ b/src/fiskaltrust.AndroidLauncher.Grpc/Broadcasting/StartLauncherBroadcastReceiver.cs
@@ -46,7 +46,15 @@ namespace fiskaltrust.AndroidLauncher.Grpc.Broadcasting
             var pending = PendingIntent.GetBroadcast(Application.Context, 0, alarmIntent, PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
 
             var alarmManager = (AlarmManager)Application.Context.GetSystemService(Context.AlarmService);
-            alarmManager.SetExact(AlarmType.ElapsedRealtime, SystemClock.ElapsedRealtime() + 100, pending);
+
+            if (Build.VERSION.SdkInt <= BuildVersionCodes.SV2)
+            {
+                alarmManager.SetExact(AlarmType.ElapsedRealtime, SystemClock.ElapsedRealtime() + 100, pending);
+            }
+            else
+            {
+                alarmManager.Set(AlarmType.ElapsedRealtime, SystemClock.ElapsedRealtime() + 100, pending);
+            }
         }
     }
 

--- a/src/fiskaltrust.AndroidLauncher.Grpc/Properties/AndroidManifest.xml
+++ b/src/fiskaltrust.AndroidLauncher.Grpc/Properties/AndroidManifest.xml
@@ -1,12 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1"
-	android:versionName="1.0" package="eu.fiskaltrust.androidlauncher.grpc"
-	android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="eu.fiskaltrust.androidlauncher.grpc" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33" />
-	<application android:allowBackup="true"
-		android:manageSpaceActivity="eu.fiskaltrust.androidlauncher.common.ManageSpaceActivity"
-		android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="true"
-		android:theme="@style/AppTheme" android:extractNativeLibs="true"></application>
+	<application android:allowBackup="true" android:manageSpaceActivity="eu.fiskaltrust.androidlauncher.common.ManageSpaceActivity" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="true" android:theme="@style/AppTheme" android:extractNativeLibs="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.INTERNET" />
@@ -14,5 +9,5 @@
 	<uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 	<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" android:maxSdkVersion="32" />
-	<uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+	<uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
 </manifest>

--- a/src/fiskaltrust.AndroidLauncher.Http/Broadcasting/StartLauncherBroadcastReceiver.cs
+++ b/src/fiskaltrust.AndroidLauncher.Http/Broadcasting/StartLauncherBroadcastReceiver.cs
@@ -46,7 +46,15 @@ namespace fiskaltrust.AndroidLauncher.Http.Broadcasting
             var pending = PendingIntent.GetBroadcast(Application.Context, 0, alarmIntent, PendingIntentFlags.UpdateCurrent | PendingIntentFlags.Immutable);
 
             var alarmManager = (AlarmManager)Application.Context.GetSystemService(Context.AlarmService);
-            alarmManager.SetExact(AlarmType.ElapsedRealtime, SystemClock.ElapsedRealtime() + 100, pending);
+
+            if (Build.VERSION.SdkInt <= BuildVersionCodes.SV2)
+            {
+                alarmManager.SetExact(AlarmType.ElapsedRealtime, SystemClock.ElapsedRealtime() + 100, pending);
+            }
+            else
+            {
+                alarmManager.Set(AlarmType.ElapsedRealtime, SystemClock.ElapsedRealtime() + 100, pending);
+            }
         }
     }
 

--- a/src/fiskaltrust.AndroidLauncher.Http/Properties/AndroidManifest.xml
+++ b/src/fiskaltrust.AndroidLauncher.Http/Properties/AndroidManifest.xml
@@ -1,18 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1"
-	android:versionName="1.0" package="eu.fiskaltrust.androidlauncher.http"
-	android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="eu.fiskaltrust.androidlauncher.http" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="24" android:targetSdkVersion="33" />
-	<application android:allowBackup="true"
-		android:manageSpaceActivity="eu.fiskaltrust.androidlauncher.common.ManageSpaceActivity"
-		android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="true"
-		android:theme="@style/AppTheme" android:extractNativeLibs="true"
-		android:usesCleartextTraffic="true"></application>
+	<application android:allowBackup="true" android:manageSpaceActivity="eu.fiskaltrust.androidlauncher.common.ManageSpaceActivity" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="true" android:theme="@style/AppTheme" android:extractNativeLibs="true" android:usesCleartextTraffic="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 	<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" android:maxSdkVersion="32" />
-	<uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+	<uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
 </manifest>


### PR DESCRIPTION
USE_ECACT_ALARMS is prohibited to use via Google's Play store policies unless the app is a clock or a calendar. 

Fixes #83 
