### PR TITLE
Acquire WakeLock when hosting Swissbit SCUs

### DIFF
--- a/src/fiskaltrust.AndroidLauncher.Common/fiskaltrust.AndroidLauncher.Common.csproj
+++ b/src/fiskaltrust.AndroidLauncher.Common/fiskaltrust.AndroidLauncher.Common.csproj
@@ -144,10 +144,10 @@
       <Version>1.3.59</Version>
     </PackageReference>
     <PackageReference Include="fiskaltrust.Middleware.SCU.DE.Swissbit">
-      <Version>1.3.48</Version>
+      <Version>1.3.62</Version>
     </PackageReference>
     <PackageReference Include="fiskaltrust.Middleware.SCU.DE.SwissbitAndroid">
-      <Version>1.3.48</Version>
+      <Version>1.3.62</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore">
       <Version>2.2.0</Version>

--- a/src/fiskaltrust.AndroidLauncher.Grpc/Properties/AndroidManifest.xml
+++ b/src/fiskaltrust.AndroidLauncher.Grpc/Properties/AndroidManifest.xml
@@ -10,4 +10,5 @@
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 	<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" android:maxSdkVersion="32" />
 	<uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/src/fiskaltrust.AndroidLauncher.Http/Properties/AndroidManifest.xml
+++ b/src/fiskaltrust.AndroidLauncher.Http/Properties/AndroidManifest.xml
@@ -9,4 +9,5 @@
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 	<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" android:maxSdkVersion="32" />
 	<uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>


### PR DESCRIPTION
This PR acquires an Android WakeLock from the Middleware when it's hosting a Swissbit Hardware SCU. While not required in most cases, in some slow-hardware scenarios (on payment terminals) Android seems to switch off parts of the CPU _or_ the device management _or_ the system clock, which resets the Swissbit TSE and enforces constant self-tests.

As these self tests take ~30 seconds, this renders the TSE unusable on these devices. A WakeLock seems to prevent this.

- [x] Add WakeLock
- [x] Update Swissbit SCU to 1.3.62