### PR TITLE
Add GitHub Actions workflow for Android smoke tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -123,3 +123,8 @@ jobs:
           az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.aab --name android/fiskaltrust-middleware-launcher-android/preview/${{env.RELEASE_VERSION}}/eu.fiskaltrust.androidlauncher-Signed-${{env.RELEASE_VERSION}}.aab
           az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.apk --name android/fiskaltrust-middleware-launcher-android/preview/eu.fiskaltrust.androidlauncher-Signed.apk --overwrite
           az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.aab --name android/fiskaltrust-middleware-launcher-android/preview/eu.fiskaltrust.androidlauncher-Signed.aab --overwrite
+
+  smoke-tests:
+    needs: buildAndroid
+    uses: ./.github/workflows/smoke-tests.yml
+    secrets: inherit

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   contents: write
+  checks: write
+  pull-requests: write
 
 env:
   BUILD_CONFIGURATION: Release
@@ -20,6 +22,9 @@ env:
 jobs:
   buildAndroid:
     runs-on: windows-latest
+    outputs:
+      release_version: ${{ steps.version.outputs.release_version }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
 
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +39,7 @@ jobs:
           dotnet-version: "10.x.x"
 
       - name: Resolve version from Nerdbank.GitVersion
+        id: version
         shell: bash
         run: |
           dotnet tool install --global nbgv
@@ -42,13 +48,10 @@ jobs:
           NBGV_SEMVER2=$(nbgv get-version -v SemVer2)
           NBGV_PRERELEASE_VERSION=$(nbgv get-version -v PrereleaseVersion)
 
-          echo "NBGV_SEMVER2=${NBGV_SEMVER2}" >> $GITHUB_ENV
-          echo "NBGV_PRERELEASE_VERSION=${NBGV_PRERELEASE_VERSION}" >> $GITHUB_ENV
-
           if [[ -n "${NBGV_PRERELEASE_VERSION}" ]]; then
-            echo "NBGV_IS_PRERELEASE=true" >> $GITHUB_ENV
+            IS_PRERELEASE=true
           else
-            echo "NBGV_IS_PRERELEASE=false" >> $GITHUB_ENV
+            IS_PRERELEASE=false
           fi
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
@@ -60,15 +63,14 @@ jobs:
               exit 1
             fi
 
-            echo "RELEASE_VERSION=${TAG_VERSION}" >> $GITHUB_ENV
+            RELEASE_VERSION="${TAG_VERSION}"
           else
-            echo "RELEASE_VERSION=${NBGV_SEMVER2}" >> $GITHUB_ENV
+            RELEASE_VERSION="${NBGV_SEMVER2}"
           fi
 
-      - name: Print version
-        shell: bash
-        run: |
-          echo "Release Version: $RELEASE_VERSION"
+          echo "Release Version: ${RELEASE_VERSION}"
+          echo "release_version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=${IS_PRERELEASE}" >> "$GITHUB_OUTPUT"
 
       - name: Extract Android signing key from env
         shell: bash
@@ -103,6 +105,31 @@ jobs:
           path: |
             ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/**
 
+  smoke-tests:
+    needs: buildAndroid
+    uses: ./.github/workflows/smoke-tests.yml
+    secrets: inherit
+
+  release:
+    needs: [buildAndroid, smoke-tests]
+    if: startsWith(github.ref, 'refs/tags/') || github.ref_name == 'maui'
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.buildAndroid.outputs.release_version }}
+      NBGV_IS_PRERELEASE: ${{ needs.buildAndroid.outputs.is_prerelease }}
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifacts-android
+          path: artifacts-android
+
+      - name: Locate built artifacts
+        id: artifacts
+        run: |
+          echo "apk=$(find artifacts-android -name 'eu.fiskaltrust.androidlauncher-Signed.apk')" >> "$GITHUB_OUTPUT"
+          echo "aab=$(find artifacts-android -name 'eu.fiskaltrust.androidlauncher-Signed.aab')" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
@@ -112,19 +139,14 @@ jobs:
           prerelease: ${{ env.NBGV_IS_PRERELEASE == 'true' }}
           generate_release_notes: true
           files: |
-            ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.apk
-            ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.aab
+            ${{ steps.artifacts.outputs.apk }}
+            ${{ steps.artifacts.outputs.aab }}
 
       - name: Upload artifacts to Azure Storage
         if: "github.ref_name == 'maui'"
         shell: bash
         run: |
-          az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.apk --name android/fiskaltrust-middleware-launcher-android/preview/${{env.RELEASE_VERSION}}/eu.fiskaltrust.androidlauncher-Signed-${{env.RELEASE_VERSION}}.apk
-          az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.aab --name android/fiskaltrust-middleware-launcher-android/preview/${{env.RELEASE_VERSION}}/eu.fiskaltrust.androidlauncher-Signed-${{env.RELEASE_VERSION}}.aab
-          az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.apk --name android/fiskaltrust-middleware-launcher-android/preview/eu.fiskaltrust.androidlauncher-Signed.apk --overwrite
-          az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}}/publish/eu.fiskaltrust.androidlauncher-Signed.aab --name android/fiskaltrust-middleware-launcher-android/preview/eu.fiskaltrust.androidlauncher-Signed.aab --overwrite
-
-  smoke-tests:
-    needs: buildAndroid
-    uses: ./.github/workflows/smoke-tests.yml
-    secrets: inherit
+          az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{ steps.artifacts.outputs.apk }} --name android/fiskaltrust-middleware-launcher-android/preview/${{env.RELEASE_VERSION}}/eu.fiskaltrust.androidlauncher-Signed-${{env.RELEASE_VERSION}}.apk
+          az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{ steps.artifacts.outputs.aab }} --name android/fiskaltrust-middleware-launcher-android/preview/${{env.RELEASE_VERSION}}/eu.fiskaltrust.androidlauncher-Signed-${{env.RELEASE_VERSION}}.aab
+          az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{ steps.artifacts.outputs.apk }} --name android/fiskaltrust-middleware-launcher-android/preview/eu.fiskaltrust.androidlauncher-Signed.apk --overwrite
+          az storage blob upload --account-name ${{vars.storageaccountname}} --account-key ${{secrets.storageaccountkey}} --container-name downloads --file ${{ steps.artifacts.outputs.aab }} --name android/fiskaltrust-middleware-launcher-android/preview/eu.fiskaltrust.androidlauncher-Signed.aab --overwrite

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_CONFIGURATION: Debug
+  BUILD_CONFIGURATION: Release
   MAUI_SDK: net10.0-android
   BASE_FOLDER: src/fiskaltrust.AndroidLauncher
   TEST_FOLDER: test/fiskaltrust.AndroidLauncher.SmokeTests
@@ -47,6 +47,8 @@ jobs:
           dotnet build ${{env.BASE_FOLDER}}/fiskaltrust.AndroidLauncher.csproj \
             -f ${{env.MAUI_SDK}} \
             -c ${{env.BUILD_CONFIGURATION}} \
+            -p:AndroidEnableR8=true \
+            -p:AndroidLinkTool=r8 \
             -t:SignAndroidPackage
 
       - name: Locate built APK
@@ -75,8 +77,7 @@ jobs:
 
             adb install -r "${{ steps.apk.outputs.path }}"
 
-            adb shell am start -n ${{env.APP_PACKAGE}}/${{env.APP_PACKAGE}}.MainActivity
-            sleep 30
+            adb shell am start -W -n ${{env.APP_PACKAGE}}/${{env.APP_PACKAGE}}.MainActivity
 
             dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal
         env:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,6 +1,8 @@
 name: Android Smoke Tests
 
 on:
+  pull_request:
+    branches: [maui]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           dotnet build ${{env.BASE_FOLDER}}/fiskaltrust.AndroidLauncher.csproj \
             -f ${{env.MAUI_SDK}} \
-            -c ${{env.BUILD_CONFIGURATION}}
+            -c ${{env.BUILD_CONFIGURATION}} \
+            -t:SignAndroidPackage
 
       - name: Locate built APK
         id: apk

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -75,6 +75,9 @@ jobs:
 
             adb install -r "${{ steps.apk.outputs.path }}"
 
+            adb shell am start -n ${{env.APP_PACKAGE}}/${{env.APP_PACKAGE}}.MainActivity
+            sleep 30
+
             dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal
         env:
           CASHBOXID: ${{ secrets.SMOKETEST_CASHBOXID }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -65,7 +65,7 @@ jobs:
           script: |
             npm install -g appium
             appium driver install uiautomator2
-            appium --port 4723 --allow-insecure=adb_shell --log appium.log &
+            appium --port 4723 --allow-insecure=uiautomator2:adb_shell --log appium.log &
 
             npx wait-on tcp:4723 --timeout 60000
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   smoke-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +72,8 @@ jobs:
           script: |
             npm install -g appium
             appium driver install uiautomator2
-            appium --port 4723 --allow-insecure=uiautomator2:adb_shell --log appium.log &
+            appium --port 4723 --allow-insecure=uiautomator2:adb_shell --log appium.log > /dev/null 2>&1 &
+            APPIUM_PID=$!
 
             npx wait-on tcp:4723 --timeout 60000
 
@@ -80,6 +82,8 @@ jobs:
             adb shell am start -W -n ${{env.APP_PACKAGE}}/${{env.APP_PACKAGE}}.MainActivity
 
             dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal
+
+            kill $APPIUM_PID || true
         env:
           CASHBOXID: ${{ secrets.SMOKETEST_CASHBOXID }}
           ACCESSTOKEN: ${{ secrets.SMOKETEST_ACCESSTOKEN }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -74,6 +74,7 @@ jobs:
             appium driver install uiautomator2
             appium --port 4723 --allow-insecure=uiautomator2:adb_shell --log appium.log > /dev/null 2>&1 &
             APPIUM_PID=$!
+            trap 'kill $APPIUM_PID 2>/dev/null' EXIT
 
             npx wait-on tcp:4723 --timeout 60000
 
@@ -82,8 +83,6 @@ jobs:
             adb shell am start -W -n ${{env.APP_PACKAGE}}/${{env.APP_PACKAGE}}.MainActivity
 
             dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal
-
-            kill $APPIUM_PID || true
         env:
           CASHBOXID: ${{ secrets.SMOKETEST_CASHBOXID }}
           ACCESSTOKEN: ${{ secrets.SMOKETEST_ACCESSTOKEN }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.SUBMODULES_READ }}
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -69,9 +69,7 @@ jobs:
 
             adb shell am start -W -n ${{env.APP_PACKAGE}}/${{env.APP_PACKAGE}}.MainActivity
 
-            dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal \
-              --logger "trx;LogFileName=smoke-tests.trx" \
-              --results-directory TestResults
+            dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal --logger "trx;LogFileName=smoke-tests.trx" --results-directory TestResults
         env:
           CASHBOXID: ${{ secrets.SMOKETEST_CASHBOXID }}
           ACCESSTOKEN: ${{ secrets.SMOKETEST_ACCESSTOKEN }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 env:
   TEST_FOLDER: test/fiskaltrust.AndroidLauncher.SmokeTests
   APP_PACKAGE: eu.fiskaltrust.androidlauncher
@@ -64,10 +69,20 @@ jobs:
 
             adb shell am start -W -n ${{env.APP_PACKAGE}}/${{env.APP_PACKAGE}}.MainActivity
 
-            dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal
+            dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal \
+              --logger "trx;LogFileName=smoke-tests.trx" \
+              --results-directory TestResults
         env:
           CASHBOXID: ${{ secrets.SMOKETEST_CASHBOXID }}
           ACCESSTOKEN: ${{ secrets.SMOKETEST_ACCESSTOKEN }}
+
+      - name: Publish Test Results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: Smoke Test Results
+          check_run: false
+          files: TestResults/*.trx
 
       - name: Upload Appium log
         if: always()

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -52,7 +52,10 @@ jobs:
       - name: Locate built APK
         id: apk
         run: |
-          APK_PATH=$(find ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}} -name "*-Signed.apk" -o -name "${{env.APP_PACKAGE}}.apk" | head -n 1)
+          APK_PATH=$(find ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}} -name "*-Signed.apk" | head -n 1)
+          if [ -z "$APK_PATH" ]; then
+            APK_PATH=$(find ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}} -name "${{env.APP_PACKAGE}}.apk" | head -n 1)
+          fi
           echo "path=$APK_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Run smoke tests on emulator

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,82 @@
+name: Android Smoke Tests
+
+on:
+  workflow_dispatch:
+
+env:
+  BUILD_CONFIGURATION: Debug
+  MAUI_SDK: net10.0-android
+  BASE_FOLDER: src/fiskaltrust.AndroidLauncher
+  TEST_FOLDER: test/fiskaltrust.AndroidLauncher.SmokeTests
+  APP_PACKAGE: eu.fiskaltrust.androidlauncher
+
+jobs:
+  smoke-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: recursive
+          token: ${{ secrets.SUBMODULES_READ }}
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.x.x"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install maui-android workload
+        run: dotnet workload install maui-android
+
+      - name: Build APK
+        run: |
+          dotnet build ${{env.BASE_FOLDER}}/fiskaltrust.AndroidLauncher.csproj \
+            -f ${{env.MAUI_SDK}} \
+            -c ${{env.BUILD_CONFIGURATION}}
+
+      - name: Locate built APK
+        id: apk
+        run: |
+          APK_PATH=$(find ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}} -name "*-Signed.apk" -o -name "${{env.APP_PACKAGE}}.apk" | head -n 1)
+          echo "path=$APK_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Run smoke tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_7_pro
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: |
+            npm install -g appium
+            appium driver install uiautomator2
+            appium --port 4723 --allow-insecure=adb_shell --log appium.log &
+
+            npx wait-on tcp:4723 --timeout 60000
+
+            adb install -r "${{ steps.apk.outputs.path }}"
+
+            dotnet test ${{env.TEST_FOLDER}} --filter "Category=possystemapi" -v normal
+        env:
+          CASHBOXID: ${{ secrets.SMOKETEST_CASHBOXID }}
+          ACCESSTOKEN: ${{ secrets.SMOKETEST_ACCESSTOKEN }}
+
+      - name: Upload Appium log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: appium-log
+          path: appium.log
+          if-no-files-found: ignore

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,14 +1,10 @@
 name: Android Smoke Tests
 
 on:
-  pull_request:
-    branches: [maui]
   workflow_dispatch:
+  workflow_call:
 
 env:
-  BUILD_CONFIGURATION: Release
-  MAUI_SDK: net10.0-android
-  BASE_FOLDER: src/fiskaltrust.AndroidLauncher
   TEST_FOLDER: test/fiskaltrust.AndroidLauncher.SmokeTests
   APP_PACKAGE: eu.fiskaltrust.androidlauncher
 
@@ -25,40 +21,26 @@ jobs:
           submodules: recursive
           token: ${{ secrets.SUBMODULES_READ }}
 
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.x.x"
+
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - uses: actions/setup-dotnet@v4
+      - name: Download built APK
+        uses: actions/download-artifact@v4
         with:
-          dotnet-version: "10.x.x"
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - name: Install maui-android workload
-        run: dotnet workload install maui-android
-
-      - name: Build APK
-        run: |
-          dotnet build ${{env.BASE_FOLDER}}/fiskaltrust.AndroidLauncher.csproj \
-            -f ${{env.MAUI_SDK}} \
-            -c ${{env.BUILD_CONFIGURATION}} \
-            -p:AndroidEnableR8=true \
-            -p:AndroidLinkTool=r8 \
-            -t:SignAndroidPackage
+          name: artifacts-android
+          path: artifacts-android
 
       - name: Locate built APK
         id: apk
         run: |
-          APK_PATH=$(find ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}} -name "*-Signed.apk" | head -n 1)
-          if [ -z "$APK_PATH" ]; then
-            APK_PATH=$(find ${{env.BASE_FOLDER}}/bin/${{env.BUILD_CONFIGURATION}}/${{env.MAUI_SDK}} -name "${{env.APP_PACKAGE}}.apk" | head -n 1)
-          fi
+          APK_PATH=$(find artifacts-android -name "*-Signed.apk" | head -n 1)
           echo "path=$APK_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Run smoke tests on emulator


### PR DESCRIPTION
Builds the launcher APK, boots a headless Android emulator, installs and starts Appium, deploys the APK, and runs the possystemapi smoke tests against a known-working sandbox cashbox.

<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

{Summary of the changes}

## Description

{Detail}

Fixes #{issue number}
